### PR TITLE
forceUpdate parameter and notNeedUpdate function features are added

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,13 +40,20 @@ class AppUpdate {
   getApkVersionSuccess(remote) {
     console.log("getApkVersionSuccess", remote);
     if (RNAppUpdate.versionName !== remote.versionName) {
-      if (this.options.needUpdateApp) {
+      if (remote.forceUpdate) {
+        if(this.options.forceUpdateApp) {
+          this.options.forceUpdateApp();
+        }
+        this.downloadApk(remote);
+      } else if (this.options.needUpdateApp) {
         this.options.needUpdateApp((isUpdate) => {
           if (isUpdate) {
             this.downloadApk(remote);
           }
         });
       }
+    } else if(this.options.notNeedUpdateApp) {
+      this.options.notNeedUpdateApp();
     }
   }
 
@@ -62,7 +69,14 @@ class AppUpdate {
     const progressDivider = 1;
     const downloadDestPath = `${RNFS.DocumentDirectoryPath}/NewApp.apk`;
 
-    const ret = RNFS.downloadFile({ fromUrl: remote.apkUrl, toFile: downloadDestPath, begin, progress, background: true, progressDivider });
+    const ret = RNFS.downloadFile({
+      fromUrl: remote.apkUrl,
+      toFile: downloadDestPath,
+      begin,
+      progress,
+      background: true,
+      progressDivider
+    });
 
     jobId = ret.jobId;
 
@@ -84,7 +98,7 @@ class AppUpdate {
       console.log("iosAppId doesn't exist.");
       return;
     }
-    this.GET("https://itunes.apple.com/lookup?id="+this.options.iosAppId, this.getAppStoreVersionSuccess.bind(this), this.getVersionError.bind(this));
+    this.GET("https://itunes.apple.com/lookup?id=" + this.options.iosAppId, this.getAppStoreVersionSuccess.bind(this), this.getVersionError.bind(this));
   }
 
   getAppStoreVersionSuccess(data) {
@@ -96,13 +110,20 @@ class AppUpdate {
     const version = result.version;
     const trackViewUrl = result.trackViewUrl;
     if (version !== RNAppUpdate.versionName) {
-      if (this.options.needUpdateApp) {
+      if (remote.forceUpdate) {
+        if(this.options.forceUpdateApp) {
+          this.options.forceUpdateApp();
+        }
+        RNAppUpdate.installFromAppStore(trackViewUrl);
+      } else if (this.options.needUpdateApp) {
         this.options.needUpdateApp((isUpdate) => {
           if (isUpdate) {
             RNAppUpdate.installFromAppStore(trackViewUrl);
           }
         });
       }
+    } else if(this.options.notNeedUpdateApp) {
+      this.options.notNeedUpdateApp();
     }
   }
 


### PR DESCRIPTION
Hi,

I implemented extra features because of my needs. If server sends forceUpdate (bool) property, app is automatically update itself after it runs forceUpdate function. 

Also, if app is up to date, it runs 'notNeedUpdateApp' function. So, current usage can be like this:

const appUpdate = new AppUpdate({
  ...,
  forceUpdateApp : () => {
      console.log("Force update will start")
  },
  notNeedUpdateApp: () => {
     console.log("App is up to date")
  },
});

and version json would become to like this:
{
  "versionName":"1.0.0",
  "apkUrl":"https://github.com/NewApp.apk"
  "forceUpdate": false
}

You can consider to merge it, I look forward your reply.
