### PR TITLE
Updated react installApk method

### DIFF
--- a/android/src/main/java/com/parryworld/rnappupdate/RNAppUpdate.java
+++ b/android/src/main/java/com/parryworld/rnappupdate/RNAppUpdate.java
@@ -57,7 +57,7 @@ public class RNAppUpdate extends ReactContextBaseJavaModule {
         }
         Intent intent = new Intent(Intent.ACTION_VIEW);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        intent.setDataAndType(Uri.parse("file://" + file), "application/vnd.android.package-archive");
+        intent.setDataAndType(Uri.parse("content://" + file), "application/vnd.android.package-archive");
         getCurrentActivity().startActivity(intent);
     }
 }


### PR DESCRIPTION
Updated react installApk method on the RNAppUpdate class to allow installation of apk on android versions > 5.0.

Changed the file uri path from file:// to content:// to allow the method to locate the downloaded APK.